### PR TITLE
f2fs: Fix error with NULL being undeclared

### DIFF
--- a/f2fs_utils/f2fs_utils.c
+++ b/f2fs_utils/f2fs_utils.c
@@ -53,7 +53,7 @@ static void reset_f2fs_info() {
 	config.fd = -1;
 	if (f2fs_sparse_file) {
 		sparse_file_destroy(f2fs_sparse_file);
-		f2fs_sparse_file = NULL;
+		f2fs_sparse_file = 0;
 	}
 }
 
@@ -73,6 +73,6 @@ int make_f2fs_sparse_fd(int fd, long long len,
 	sparse_file_write(f2fs_sparse_file, fd, /*gzip*/0, /*sparse*/1, /*crc*/0);
 	sparse_file_destroy(f2fs_sparse_file);
 	flush_sparse_buffs();
-	f2fs_sparse_file = NULL;
+	f2fs_sparse_file = 0;
 	return 0;
 }


### PR DESCRIPTION
This commit fixes errors similar to "system/extras/f2fs_utils/f2fs_utils.c:76:21: error: 'NULL' undeclared (first use in this function)". In the GCC compiler, NULL defaults to 0 unless otherwise stated, but the correct header file to define NULL as 0 is not included. Another way to fix this error would have been "#include cstdlib.h" but this way will make ambiguity errors arising from the value being treated as an integer more obvious.
